### PR TITLE
Convert async API to a synchronous one

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## ❓ What is this?
 
-Get a list of calendar dates.  
+Get a list of calendar dates.
 **without an External Dependency**
 
 You can use this to create your own calendar controls
@@ -21,12 +21,16 @@ Full [documentation](https://dance2die.github.io/calendar-dates/).
 
 ## Change Log
 
-### 2.4.0  
-Fixed [ISO8601 date](https://github.com/dance2die/calendar-dates/pull/21) return value to match current date.  
+### 3.0.0
+
+Converted all methods to be synchronous
+
+### 2.4.0
+Fixed [ISO8601 date](https://github.com/dance2die/calendar-dates/pull/21) return value to match current date.
 * Thank you again [ewolfe](https://github.com/ewolfe) 👊.
 
 ### 2.3.0
-1. Returns [ISO8601 date](https://github.com/dance2die/calendar-dates/pull/19).  
+1. Returns [ISO8601 date](https://github.com/dance2die/calendar-dates/pull/19).
     * Thank you [ewolfe](https://github.com/ewolfe) 🙌.
 1. Removed `package-lock.json`, which was accidentally added by using `npm` instead of `yarn`.
 
@@ -45,13 +49,13 @@ Following methods are removed
 1.  getMatrixWithMetadata
 1.  getMatrixWithMetadataAsync
 
-### 1.1.2  
+### 1.1.2
 Updated README to include `*WithMetadata` examples
 
-### 1.1.1  
+### 1.1.1
 Fixed runtimeGenerator issue
 
-### 1.1.0  
+### 1.1.0
 Added `*WithMetadata` methods
 
 ### 1.0.0
@@ -59,5 +63,5 @@ Added "\*Async" versions
 
 ## License
 
-[MIT](https://github.com/dance2die/calendar-dates/blob/master/LICENSE)  
+[MIT](https://github.com/dance2die/calendar-dates/blob/master/LICENSE)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fdance2die%2Fcalendar-dates.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fdance2die%2Fcalendar-dates?ref=badge_large)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ## What is this?
 
-Get a list of calendar dates.  
+Get a list of calendar dates.
 **without an External Dependency**
 
 You can use this to create your own calendar controls
@@ -41,8 +41,8 @@ const log = console.log;
 const may2018 = new Date(2018, 4);
 
 mainAsync = async () => {
-  const mayDates = await calendarDates.getDates(may2018);
-  const mayMatrix = await calendarDates.getMatrix(may2018);
+  const mayDates = calendarDates.getDates(may2018);
+  const mayMatrix = calendarDates.getMatrix(may2018);
   log(`May, 2018 Dates`, mayDates);
   log(`May, 2018 Matrix`, mayMatrix);
 };
@@ -119,11 +119,11 @@ import CalendarDates from "calendar-dates";
 const calendarDates = new CalendarDates();
 
 const main = async () => {
-  for (const meta of await calendarDates.getDates(new Date())) {
+  for (const meta of calendarDates.getDates(new Date())) {
     console.log(meta);
   }
 
-  for (const meta of await calendarDates.getMatrix(new Date())) {
+  for (const meta of calendarDates.getMatrix(new Date())) {
     console.log(meta);
   }
 };
@@ -163,6 +163,9 @@ Array(7) [ {…}, {…}, {…}, {…}, {…}, {…}, {…} ]
 
 ## Change Log
 
+3.0.0
+Converted all methods to be synchronous
+
 2.0.0
 Removed all methods except two methods, which return a promise.
 
@@ -178,13 +181,13 @@ Following methods are removed
 1.  getMatrixWithMetadata
 1.  getMatrixWithMetadataAsync
 
-1.1.2  
+1.1.2
 Updated README to include `*WithMetadata` examples
 
-1.1.1  
+1.1.1
 Fixed runtimeGenerator issue
 
-1.1.0  
+1.1.0
 Added `*WithMetadata` methods
 
 1.0.0
@@ -192,5 +195,5 @@ Added "\*Async" versions
 
 ## License
 
-[MIT](https://github.com/dance2die/calendar-dates/blob/master/LICENSE)  
+[MIT](https://github.com/dance2die/calendar-dates/blob/master/LICENSE)
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fdance2die%2Fcalendar-dates.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fdance2die%2Fcalendar-dates?ref=badge_large)

--- a/src/dateutil.js
+++ b/src/dateutil.js
@@ -29,31 +29,27 @@ const getFirstDayIndex = date => {
 };
 
 const getDatesWithMetadata = date => {
-  return new Promise(resolve => {
-    let result = [];
+  let result = [];
 
-    const previousDates = getPreviousDates(date).map(({ date, iso }) => ({
-      date,
-      iso,
-      type: monthTypes.PREVIOUS
-    }));
-    const currentDates = getCurrentDates(date).map(({ date, iso }) => ({
-      date,
-      iso,
-      type: monthTypes.CURRENT
-    }));
-    result = result.concat(previousDates).concat(currentDates);
+  const previousDates = getPreviousDates(date).map(({ date, iso }) => ({
+    date,
+    iso,
+    type: monthTypes.PREVIOUS
+  }));
+  const currentDates = getCurrentDates(date).map(({ date, iso }) => ({
+    date,
+    iso,
+    type: monthTypes.CURRENT
+  }));
+  result = result.concat(previousDates).concat(currentDates);
 
-    const nextDates = getNextDates(date, result.length).map(
-      ({ date, iso }) => ({
-        date,
-        iso,
-        type: monthTypes.NEXT
-      })
-    );
+  const nextDates = getNextDates(date, result.length).map(({ date, iso }) => ({
+    date,
+    iso,
+    type: monthTypes.NEXT
+  }));
 
-    resolve(result.concat(nextDates));
-  });
+  return result.concat(nextDates);
 };
 
 const getCurrentDates = date => {

--- a/src/index.js
+++ b/src/index.js
@@ -2,32 +2,20 @@ import { getDatesWithMetadata } from "./dateutil";
 
 class CalendarDates {
   getDates(date) {
-    return new Promise(resolve =>
-      resolve(
-        getDatesWithMetadata(date).then(dates =>
-          dates.map(metadata => metadata)
-        )
-      )
-    );
+    return getDatesWithMetadata(date);
   }
 
   getMatrix(date) {
     const daysInAWeek = 7; // 7 days in a week.
 
     // https://stackoverflow.com/a/39838921/4035
-    return new Promise(resolve => {
-      resolve(
-        getDatesWithMetadata(date).then(dates =>
-          dates.reduce(
-            (rows, key, index) =>
-              (index % daysInAWeek === 0
-                ? rows.push([key])
-                : rows[rows.length - 1].push(key)) && rows,
-            []
-          )
-        )
-      );
-    });
+    return getDatesWithMetadata(date).reduce(
+      (rows, key, index) =>
+        (index % daysInAWeek === 0
+          ? rows.push([key])
+          : rows[rows.length - 1].push(key)) && rows,
+      []
+    );
   }
 }
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -51,9 +51,8 @@ test("Dates with Metadata for April of 2018", () => {
     { date: 12, iso: "2018-05-12", type: "next" }
   ];
 
-  return sut
-    .getDates(april2018)
-    .then(actual => expect(actual).toEqual(expected));
+  const actual = sut.getDates(april2018);
+  expect(actual).toEqual(expected);
 });
 
 test("Dates with Metadata for May of 2018", () => {
@@ -102,7 +101,8 @@ test("Dates with Metadata for May of 2018", () => {
     { date: 9, iso: "2018-06-09", type: "next" }
   ];
 
-  return sut.getDates(may2018).then(actual => expect(actual).toEqual(expected));
+  const actual = sut.getDates(may2018);
+  expect(actual).toEqual(expected);
 });
 
 test("Date Matrix with Metadata for April of 2018", () => {
@@ -163,9 +163,8 @@ test("Date Matrix with Metadata for April of 2018", () => {
     ]
   ];
 
-  return sut
-    .getMatrix(april2018)
-    .then(actual => expect(actual).toEqual(expected));
+  const actual = sut.getMatrix(april2018);
+  expect(actual).toEqual(expected);
 });
 
 test("Date Matrix with Metadata for May of 2018", () => {
@@ -226,7 +225,6 @@ test("Date Matrix with Metadata for May of 2018", () => {
     ]
   ];
 
-  return sut
-    .getMatrix(may2018)
-    .then(actual => expect(actual).toEqual(expected));
+  const actual = sut.getMatrix(may2018);
+  expect(actual).toEqual(expected);
 });


### PR DESCRIPTION
I ran into the "issue" of this library being async while running jest snapshot testing.

This pull request refactors the API to be synchronous. It also updates all of the documentation, changelog, etc.